### PR TITLE
Added attribute is used to mark classes that allow dynamic properties

### DIFF
--- a/src/SypexGeo.php
+++ b/src/SypexGeo.php
@@ -20,6 +20,7 @@ define ('SXGEO_FILE', 0);
 define ('SXGEO_MEMORY', 1);
 define ('SXGEO_BATCH',  2);
 
+#[\AllowDynamicProperties]
 class SypexGeo 
 {
 


### PR DESCRIPTION
Fix "Deprecated: Creation of dynamic property"
Compatible with older versions of php